### PR TITLE
Remove composer require checker - it should be run elsewhere

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
     "require": {
         "phpro/grumphp": "^1.13",
         "headsnet/grumphp-gitlab-lint": "^0.1.0",
-        "ergebnis/composer-normalize": "^2.2",
-        "maglnet/composer-require-checker": "^3.8"
+        "ergebnis/composer-normalize": "^2.2"
     },
     "config": {
         "allow-plugins": {
-            "phpro/grumphp": true
+            "phpro/grumphp": true,
+            "ergebnis/composer-normalize": true
         }
     }
 }

--- a/grumphp.conventions.yml
+++ b/grumphp.conventions.yml
@@ -17,9 +17,6 @@ grumphp:
     tasks:
         composer: ~      # Runs "composer validate" to check the file when it's been changed
         composer_normalize: ~
-        composer_require_checker:
-            ignore_parse_errors: true
-        #deptrac: ~
         doctrine_schema_check:
             scripts: [ [ '-c', '%convention.doctrine_schema_check.command%' ] ]
             triggered_by: [ xml, yaml, php ]
@@ -79,5 +76,3 @@ grumphp:
                 - phpunitbridge_all
                 - doctrine_schema_check
                 - phpstan_all
-                #- deptrac
-                - composer_require_checker


### PR DESCRIPTION
Composer require checker is very, very slow - takes around 60 seconds to run on a small-ish codebase. We also don't need this running on every push - it's just overkill.

This commit removes composer require checker.

Recommend to run it during a nightly CI build instead.